### PR TITLE
Add setters and getters for shipType and length Ship attributes

### DIFF
--- a/src/main/java/cs361/battleships/models/Ship.java
+++ b/src/main/java/cs361/battleships/models/Ship.java
@@ -31,4 +31,12 @@ public class Ship {
 	public List<Square> getOccupiedSquares() { return occupiedSquares; }
 
 	public void setOccupiedSquares(List<Square> location) { occupiedSquares.addAll(location); }
+
+	public String getShipType() { return shipType; }
+
+	public void setShipType(String kind) { shipType = kind; }
+
+	public int getLength() { return length; }
+
+	public void setLength(int length) { this.length = length; }
 }


### PR DESCRIPTION
This PR actually accounts for the fact that all of the Ship class's attributes need their own setters and getters.